### PR TITLE
PKG-10349: evaluate 0.4.6 correction

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,8 @@ package:
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: e07036ca12b3c24331f83ab787f21cc2dbf3631813a1631e63e40897c69a3f21
-  - url: https://github.com/huggingface/evaluate/archive/refs/tags/v0.4.3.tar.gz
-    sha256: af193874d5fdd3c4321e1b740e3f67232fac950d357dfd9034337e8c17a5d09e
+  - url: https://github.com/huggingface/evaluate/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: f504992d7dc5a526a3b8e1fc0f7b990874ae0b3576d5cab92db6438f62e255c4
     folder: gh_src
 
 build:


### PR DESCRIPTION
evaluate 0.4.6

**Destination channel:** Defaults

### Links

- [PKG-10349]
- dev_url:        https://github.com/huggingface/evaluate/releases/tag/v0.4.6
- conda_forge:    https://github.com/conda-forge/evaluate-feedstock
- pypi:           https://pypi.org/project/evaluate/0.4.6
- pypi inspector: https://inspector.pypi.io/project/evaluate/0.4.6

### Explanation of changes:
- correct tests


[PKG-10349]: https://anaconda.atlassian.net/browse/PKG-10349