### PR TITLE
evaluate 0.4.6 (enable py3.14)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,12 +13,11 @@ source:
     folder: gh_src
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - evaluate-cli=evaluate.commands.evaluate_cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  # No huggingface_hub <0.31.0 in main for py314
-  skip: true  # [py<38 or py>313]
+  skip: true  # [py<38]
 
 requirements:
   host:


### PR DESCRIPTION
evaluate 0.4.6 (enable py3.14)

**Destination channel:** defaults

Recipe-only rebuild to add the **py3.14** build of `evaluate 0.4.6` (build number 1 → **2**). No version change.

**Why:** `evaluate` was capped at py3.13 by `skip: true  # [py<38 or py>313]`, added when there was "no huggingface_hub <0.31.0 in main for py314". That constraint is gone — transformers 5.9.0 now uses huggingface_hub 1.15.0, and every run + test dep has a py3.14 build on pkgs/main. A dry-run solve of the full env (run + test) on py3.14 resolves cleanly.

This unblocks **lm_eval 0.4.11** (PKG-15655), whose py3.14 test currently fails to solve because `evaluate >=0.4.0` has no py3.14 build. Part of the axolotl 0.17.0 chain (epic PKG-14944).

**Ticket:** [PKG-16618](https://anaconda.atlassian.net/browse/PKG-16618) (evaluate 0.4.6 py3.14) — blocks [PKG-15655](https://anaconda.atlassian.net/browse/PKG-15655) (lm_eval).

### Changes
- `build.number` 1 → 2 (all variants get distinct channel identities; py3.10–3.13 rebuild, py3.14 added)
- Removed `or py>313` from the skip selector (now `skip: true  # [py<38]`) and the obsolete `huggingface_hub <0.31.0` comment

### Verification
- `python-xxhash` (the actual xxhash dep) already ships py3.14; the `xxhash` C-lib is arch-only
- All run deps + all 11 test.requires deps (pytorch, transformers, jiwer, nltk, scipy, …) have py3.14 on pkgs/main
- `conda create --dry-run python=3.14 <run+test deps> -c pkgs/main` → solves (huggingface_hub 1.15.0, pytorch 2.12.0, transformers 5.9.0)



[PKG-16618]: https://anaconda.atlassian.net/browse/PKG-16618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-15655]: https://anaconda.atlassian.net/browse/PKG-15655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ